### PR TITLE
use omniauth-rails_csrf_protection gem to protect against Cross-Site Request Forgery CVE-2015-9284

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,11 @@ To add single sign on you will need to add the [omniauth gem](https://github.com
 to your gem file, along with the omniauth gem for your chosen
 [provider](https://github.com/omniauth/omniauth/wiki/List-of-Strategies).
 
+**n.b. You also need to add the `omniauth-rails_csrf_protection` gem to your Gemfile.**
+This is required to protect your app from Cross-Site Request Forgery.
+For more information see the [omniauth wiki page](https://github.com/omniauth/omniauth/wiki/Resolving-CVE-2015-9284)
+on CVE-2015-9284.
+
 In `config/initializers/balrog.rb`, call `config.set_omniauth` in the setup block.
 `.set_omniauth` takes the same arguments as the `OmniAuth::Builder#provider`
 [method](https://github.com/omniauth/omniauth#getting-started),
@@ -185,6 +190,10 @@ Balrog::Middleware.setup do |config|
   config.set_domain_whitelist 'pixielabs.io', 'the_fellowship.com'
 end
 ```
+If you have configured the Balrog gate view, make sure that all requests to
+`/auth/:provider` are `POST` requests. i.e. use `button_to` not `link_to`.
+For an example, see the [balrog gate in the spec app](https://github.com/pixielabs/balrog/blob/master/spec/dummy-rails-app/app/views/balrog/gate.html.erb),
+or for more information see the [omniauth wiki page](https://github.com/omniauth/omniauth/wiki/Resolving-CVE-2015-9284).
 
 ## Upgrading from 1.1 to 2.0
 

--- a/README.md
+++ b/README.md
@@ -166,11 +166,6 @@ To add single sign on you will need to add the [omniauth gem](https://github.com
 to your gem file, along with the omniauth gem for your chosen
 [provider](https://github.com/omniauth/omniauth/wiki/List-of-Strategies).
 
-**n.b. You also need to add the `omniauth-rails_csrf_protection` gem to your Gemfile.**
-This is required to protect your app from Cross-Site Request Forgery.
-For more information see the [omniauth wiki page](https://github.com/omniauth/omniauth/wiki/Resolving-CVE-2015-9284)
-on CVE-2015-9284.
-
 In `config/initializers/balrog.rb`, call `config.set_omniauth` in the setup block.
 `.set_omniauth` takes the same arguments as the `OmniAuth::Builder#provider`
 [method](https://github.com/omniauth/omniauth#getting-started),
@@ -190,10 +185,10 @@ Balrog::Middleware.setup do |config|
   config.set_domain_whitelist 'pixielabs.io', 'the_fellowship.com'
 end
 ```
-If you have configured the Balrog gate view, make sure that all requests to
-`/auth/:provider` are `POST` requests. i.e. use `button_to` not `link_to`.
-For an example, see the [balrog gate in the spec app](https://github.com/pixielabs/balrog/blob/master/spec/dummy-rails-app/app/views/balrog/gate.html.erb),
-or for more information see the [omniauth wiki page](https://github.com/omniauth/omniauth/wiki/Resolving-CVE-2015-9284).
+**Please note:** there is currently a CSRF vulnerability which affects OmniAuth 
+(designated [CVE-2015-9284](https://nvd.nist.gov/vuln/detail/CVE-2015-9284)) 
+that requires mitigation at the application level. More details on how to do 
+this can be found on the [Omniauth Wiki](https://github.com/omniauth/omniauth/wiki/Resolving-CVE-2015-9284).
 
 ## Upgrading from 1.1 to 2.0
 

--- a/app/views/balrog/gate.html.erb
+++ b/app/views/balrog/gate.html.erb
@@ -7,7 +7,7 @@
       </form>
     <% end %>
     <% if balrog_omniauth_configured? %>
-      <%= link_to(
+      <%= button_to(
         "Sign in with SSO",
         "/auth/#{Balrog::Middleware.omniauth_config[:provider]}",
         class: 'button_background sso_button'

--- a/spec/dummy-rails-app/Gemfile
+++ b/spec/dummy-rails-app/Gemfile
@@ -28,6 +28,9 @@ gem 'jbuilder', '~> 2.5'
 gem 'bcrypt', '~> 3.1.7'
 # Use OmniAuth for single sign-on
 gem 'omniauth'
+# Use csrf protection to patch the Cross-Site Request Forgery
+# security vunerability: CVE-2015-9284
+gem "omniauth-rails_csrf_protection"
 # Use google as the OmniAuth provider
 gem 'omniauth-google-oauth2'
 

--- a/spec/dummy-rails-app/Gemfile.lock
+++ b/spec/dummy-rails-app/Gemfile.lock
@@ -143,6 +143,9 @@ GEM
     omniauth-oauth2 (1.6.0)
       oauth2 (~> 1.1)
       omniauth (~> 1.9)
+    omniauth-rails_csrf_protection (0.1.2)
+      actionpack (>= 4.2)
+      omniauth (>= 1.3.1)
     public_suffix (4.0.1)
     puma (3.12.1)
     rack (2.0.7)
@@ -275,6 +278,7 @@ DEPENDENCIES
   listen (>= 3.0.5, < 3.2)
   omniauth
   omniauth-google-oauth2
+  omniauth-rails_csrf_protection
   puma (~> 3.11)
   rails (~> 6.0)
   redis

--- a/spec/dummy-rails-app/app/views/balrog/gate.html.erb
+++ b/spec/dummy-rails-app/app/views/balrog/gate.html.erb
@@ -11,7 +11,7 @@
       </form>
     <% end %>
     <% if balrog_omniauth_configured? %>
-      <%= link_to(
+      <%= button_to(
         "Sign in with SSO",
         "/auth/#{Balrog::Middleware.omniauth_config[:provider]}",
         class: 'button_background sso_button'

--- a/spec/dummy-rails-app/spec/features/viewing_admin_pages_spec.rb
+++ b/spec/dummy-rails-app/spec/features/viewing_admin_pages_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe "Viewing admin pages" do
     context "using single sign on" do
       it "shows the admin page" do
         visit '/admin'
-        click_link 'Sign in with SSO'
+        click_button 'Sign in with SSO'
         expect(page).to have_text "Let me in, I'm Admin#Index."
       end
       describe "with the wrong email" do
@@ -37,7 +37,7 @@ RSpec.describe "Viewing admin pages" do
             info: { email: "samwise@shire-landscaping.org" }
           )
           visit '/admin'
-          click_link 'Sign in with SSO'
+          click_button 'Sign in with SSO'
           expect(page).to_not have_text "Let me in, I'm Admin#Index."
           expect(page).to have_field 'password'
         end

--- a/spec/dummy-rails-app/spec/features/viewing_sidekiq-web_spec.rb
+++ b/spec/dummy-rails-app/spec/features/viewing_sidekiq-web_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe "Viewing Sidekiq" do
     context "using single sign on" do
       it "shows the admin page" do
         visit '/sidekiq'
-        click_link 'Sign in with SSO'
+        click_button 'Sign in with SSO'
         expect(page).to have_text "Sidekiq"
       end
       describe "with the wrong email" do
@@ -37,7 +37,7 @@ RSpec.describe "Viewing Sidekiq" do
             info: { email: "pippin@fool-of-a-took.co.uk" }
           )
           visit '/sidekiq'
-          click_link 'Sign in with SSO'
+          click_button 'Sign in with SSO'
           expect(page).to_not have_text "Sidekiq"
           expect(page).to have_field 'password'
         end


### PR DESCRIPTION
## use `omniauth-rails_csrf_protection` gem to protect against CSRF CVE-2015-9284

### Resources
- [omniauth-rails_csrf_protection](https://github.com/cookpad/omniauth-rails_csrf_protection) gem README
- [omniauth wiki page](https://github.com/omniauth/omniauth/wiki/Resolving-CVE-2015-9284) on CVE-2015-9284

### Includes
- User must use the `omniauth-rails_csrf_protection` gem to protect against Cross-Site Request Forgery attacks.
- This gem does a few things to your application:
  - Disables access to the OAuth request phase using `HTTP GET` method.
  - Inserts a Rails CSRF token verifier at the before request phase.
- All requests to `/auth/:provider` must be `POST` requests.
- Changes to README alerting users to this.
