### PR TITLE
patch for bug with activerecord-session_store gem

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,11 +220,19 @@ end
 
 ### Running the tests
 
-Tests are part of the dummy Rails app within the spec folder:
+Tests are part of the dummy Rails app within the spec folder. To run the tests:
 
 ```
 $ cd spec/dummy-rails-app
 $ bundle
+$ rails generate active_record:session_migration
+$ redis-server
+```
+
+Then in a different terminal:
+
+```
+$ cd spec/dummy-rails-app
 $ rspec
 ```
 

--- a/lib/balrog/guard.rb
+++ b/lib/balrog/guard.rb
@@ -2,7 +2,7 @@
 # and that the session hasn't expired.
 module Balrog::Guard
   def authenticated?(balrog_session)
-    @balrog_session = balrog_session
+    @balrog_session = balrog_session&.with_indifferent_access
     previously_authenticated? && still_valid?
   end
 
@@ -11,14 +11,14 @@ module Balrog::Guard
   # A method to check that the user has been authenticated before.
   def previously_authenticated?
     return false unless @balrog_session
-    @balrog_session['value'] == 'authenticated'
+    @balrog_session[:value] == 'authenticated'
   end
 
   # A method to check that the authentication has not expired.
   def still_valid?
     # If the user did not set configured the Balrog session 
     # to expire, the cookie is valid.
-    return true unless @balrog_session['expiry_date']
-    DateTime.current < @balrog_session['expiry_date']
+    return true unless @balrog_session[:expiry_date]
+    DateTime.current < @balrog_session[:expiry_date]
   end
 end

--- a/spec/dummy-rails-app/Gemfile
+++ b/spec/dummy-rails-app/Gemfile
@@ -41,6 +41,9 @@ gem 'redis'
 # Use foreman to run Procfile
 gem 'foreman'
 
+# Included to ensure Balrog works with activerecord-session_store
+gem 'activerecord-session_store'
+
 # Use ActiveStorage variant
 # gem 'mini_magick', '~> 4.8'
 

--- a/spec/dummy-rails-app/Gemfile.lock
+++ b/spec/dummy-rails-app/Gemfile.lock
@@ -45,6 +45,12 @@ GEM
     activerecord (6.0.1)
       activemodel (= 6.0.1)
       activesupport (= 6.0.1)
+    activerecord-session_store (1.1.3)
+      actionpack (>= 4.0)
+      activerecord (>= 4.0)
+      multi_json (~> 1.11, >= 1.11.2)
+      rack (>= 1.5.2, < 3)
+      railties (>= 4.0)
     activestorage (6.0.1)
       actionpack (= 6.0.1)
       activejob (= 6.0.1)
@@ -267,6 +273,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  activerecord-session_store
   bcrypt (~> 3.1.7)
   bootsnap (>= 1.1.0)
   byebug

--- a/spec/dummy-rails-app/config/initializers/session_store.rb
+++ b/spec/dummy-rails-app/config/initializers/session_store.rb
@@ -1,0 +1,1 @@
+Rails.application.config.session_store :active_record_store, :key => '_app_session'	

--- a/spec/dummy-rails-app/db/migrate/20200911082335_add_sessions_table.rb
+++ b/spec/dummy-rails-app/db/migrate/20200911082335_add_sessions_table.rb
@@ -1,0 +1,12 @@
+class AddSessionsTable < ActiveRecord::Migration[6.0]
+  def change
+    create_table :sessions do |t|
+      t.string :session_id, :null => false
+      t.text :data
+      t.timestamps
+    end
+
+    add_index :sessions, :session_id, :unique => true
+    add_index :sessions, :updated_at
+  end
+end

--- a/spec/dummy-rails-app/db/schema.rb
+++ b/spec/dummy-rails-app/db/schema.rb
@@ -1,0 +1,24 @@
+# This file is auto-generated from the current state of the database. Instead
+# of editing this file, please use the migrations feature of Active Record to
+# incrementally modify your database, and then regenerate this schema definition.
+#
+# This file is the source Rails uses to define your schema when running `rails
+# db:schema:load`. When creating a new database, `rails db:schema:load` tends to
+# be faster and is potentially less error prone than running all of your
+# migrations from scratch. Old migrations may fail to apply correctly if those
+# migrations use external dependencies or application code.
+#
+# It's strongly recommended that you check this file into your version control system.
+
+ActiveRecord::Schema.define(version: 2020_09_11_082335) do
+
+  create_table "sessions", force: :cascade do |t|
+    t.string "session_id", null: false
+    t.text "data"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["session_id"], name: "index_sessions_on_session_id", unique: true
+    t.index ["updated_at"], name: "index_sessions_on_updated_at"
+  end
+
+end


### PR DESCRIPTION
Patch for issue #40 

Without the 'activerecord-session_store' gem, `env['rack.session']` stores the keys as strings.
With the gem, `env[rack.session]` stores the keys as they are entered.

This fix is call  `with_indifferent_access`on the `balrog_session`.